### PR TITLE
Update jsDelivr link

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Let me know if you're using TheaterJS, I'd be glad to add it to this list.
 
 * via bower: `bower install theaterjs`
 * via npm: `npm install theaterjs`
-* via CDN: `//cdn.jsdelivr.net/gh/zhouzi/theaterjs@latest/dist/theater.min.js`
+* via CDN: `//cdn.jsdelivr.net/npm/theaterjs@latest/dist/theater.min.js`
 * [direct download](https://github.com/Zhouzi/TheaterJS/releases)
 
 Link the `theater.min.js` file and you're done: `<script src="path/to/theater.min.js"></script>`

--- a/README.md
+++ b/README.md
@@ -31,8 +31,7 @@ Let me know if you're using TheaterJS, I'd be glad to add it to this list.
 
 * via bower: `bower install theaterjs`
 * via npm: `npm install theaterjs`
-* via CDN (CommonJS): `//cdn.jsdelivr.net/npm/theaterjs@latest/index.min.js`
-* via CDN (UMD): `//cdn.jsdelivr.net/gh/zhouzi/theaterjs@latest/dist/theater.min.js`
+* via CDN: `//cdn.jsdelivr.net/gh/zhouzi/theaterjs@latest/dist/theater.min.js`
 * [direct download](https://github.com/Zhouzi/TheaterJS/releases)
 
 Link the `theater.min.js` file and you're done: `<script src="path/to/theater.min.js"></script>`

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ Let me know if you're using TheaterJS, I'd be glad to add it to this list.
 
 * via bower: `bower install theaterjs`
 * via npm: `npm install theaterjs`
-* via a cdn: `//cdn.jsdelivr.net/npm/theaterjs@latest/index.min.js`
+* via CDN (CommonJS): `//cdn.jsdelivr.net/npm/theaterjs@latest/index.min.js`
+* via CDN (UMD): `//cdn.jsdelivr.net/gh/zhouzi/theaterjs@latest/dist/theater.min.js`
 * [direct download](https://github.com/Zhouzi/TheaterJS/releases)
 
 Link the `theater.min.js` file and you're done: `<script src="path/to/theater.min.js"></script>`

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Let me know if you're using TheaterJS, I'd be glad to add it to this list.
 
 * via bower: `bower install theaterjs`
 * via npm: `npm install theaterjs`
-* via a cdn: `//cdn.jsdelivr.net/theaterjs/latest/theater.min.js`
+* via a cdn: `//cdn.jsdelivr.net/npm/theaterjs@latest/index.min.js`
 * [direct download](https://github.com/Zhouzi/TheaterJS/releases)
 
 Link the `theater.min.js` file and you're done: `<script src="path/to/theater.min.js"></script>`

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build": "webpack && webpack -d -p"
   },
   "main": "index.js",
+  "jsdelivr": "dist/theater.min.js",
   "files": [
     "dist",
     "index.js",


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the link now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/npm/theaterjs.

Feel free to ping me if you have any questions regarding this change.